### PR TITLE
Remove populated recipient address

### DIFF
--- a/ui/src/components/Bridge.js
+++ b/ui/src/components/Bridge.js
@@ -46,9 +46,6 @@ export class Bridge extends React.Component {
             reverse
           })
         }
-        this.setState({
-          recipient: web3Store.defaultAccount.address
-        })
       }
     })
   }

--- a/ui/src/components/BridgeForm.js
+++ b/ui/src/components/BridgeForm.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const BridgeForm = ({ reverse, currency, onTransfer, onAmountInputChange, onRecipientInputChange, displayArrow, recipient }) => (
+export const BridgeForm = ({ reverse, currency, onTransfer, onAmountInputChange, onRecipientInputChange, displayArrow }) => (
   <div className="form-container">
     {displayArrow &&
       <div className={`transfer-line ${displayArrow ? 'transfer-right' : ''}`}>
@@ -20,7 +20,7 @@ export const BridgeForm = ({ reverse, currency, onTransfer, onAmountInputChange,
                 type="text"
                 className="bridge-form-input"
                 id="amount"
-                placeholder="0"
+                placeholder="0x0"
               />
               <label htmlFor="amount" className="bridge-form-label">
                 {currency}
@@ -37,8 +37,8 @@ export const BridgeForm = ({ reverse, currency, onTransfer, onAmountInputChange,
                 pattern="0x[0-9a-fA-F]{40}"
                 className="bridge-form-input"
                 id="recipient"
-                placeholder="0x00"
-                value={recipient}
+                placeholder="0x0"
+                value={""}
               />
             </div>
           </div>

--- a/ui/src/components/BridgeForm.js
+++ b/ui/src/components/BridgeForm.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const BridgeForm = ({ reverse, currency, onTransfer, onAmountInputChange, onRecipientInputChange, displayArrow }) => (
+export const BridgeForm = ({ reverse, currency, onTransfer, onAmountInputChange, onRecipientInputChange, displayArrow, recipient }) => (
   <div className="form-container">
     {displayArrow &&
       <div className={`transfer-line ${displayArrow ? 'transfer-right' : ''}`}>
@@ -38,7 +38,7 @@ export const BridgeForm = ({ reverse, currency, onTransfer, onAmountInputChange,
                 className="bridge-form-input"
                 id="recipient"
                 placeholder="0x0"
-                value={""}
+                value={recipient}
               />
             </div>
           </div>

--- a/ui/src/components/BridgeForm.js
+++ b/ui/src/components/BridgeForm.js
@@ -20,7 +20,7 @@ export const BridgeForm = ({ reverse, currency, onTransfer, onAmountInputChange,
                 type="text"
                 className="bridge-form-input"
                 id="amount"
-                placeholder="0x0"
+                placeholder="0"
               />
               <label htmlFor="amount" className="bridge-form-label">
                 {currency}


### PR DESCRIPTION
Remove the populated recipient address from the stablecoin UI. previously, this address was the one injected into the browser; however, this has proved unreliable in situations such as Trust Wallet where the user may not want to send back to the same address they're currently using.

@bingmao-tt this is a minor change, lmk what you need from me to get this deployed