### PR TITLE
getEvents: batch getBlockNumber and getLogs in one request

### DIFF
--- a/validator/src/tx/batch.js
+++ b/validator/src/tx/batch.js
@@ -1,0 +1,43 @@
+class BatchRequest {
+  constructor(web3) {
+    this.b = new web3.BatchRequest();
+    this.results = [];
+    this.resolve = null;
+    this.reject = null;
+    this.resultsFilled = 0;
+  }
+  web3BatchRequestCallBack(index, err, result) {
+    /* if any request in our batch fails, reject the promise we return from `execute` */
+    if (err) {
+      this.reject(new Error(`request ${index} failed: ${err}`))
+      return;
+    }
+    this.results[index] = result;
+    this.resultsFilled++;
+    if (this.resultsFilled === this.results.length) {
+      this.resolve(this.results);
+    }
+  }
+  resultPromiseExecutor(resolve, reject) {
+    this.resolve = resolve;
+    this.reject = reject;
+  }
+  add(method /* web3-core-method.Method */) {
+    const index = this.results.length;
+    method.callback = (err, result) => {
+      this.web3BatchRequestCallBack(index, err, result)
+    };
+    this.b.add(method);
+    this.results.push(undefined);
+  }
+  execute() /*: Promise */ {
+    const p = new Promise((resolve, reject) => { this.resultPromiseExecutor(resolve, reject) });
+    /* must arrange for resultPromiseExecutor to be called before b.execute */
+    this.b.execute();
+    return p;
+  }
+}
+
+module.exports = {
+  BatchRequest: BatchRequest,
+}

--- a/validator/src/tx/web3.js
+++ b/validator/src/tx/web3.js
@@ -2,6 +2,7 @@ const logger = require('../services/logger').child({
   module: 'web3'
 })
 const { sendRawTx } = require('./sendTx')
+const { BatchRequest } = require('./batch')
 const { hexToNumber } = require('web3-utils')
 
 async function getNonce(web3, address) {
@@ -57,19 +58,90 @@ async function getRequiredBlockConfirmations(contract) {
   }
 }
 
-async function getEvents({ contract, event, fromBlock, toBlock, filter }) {
-  try {
-    const contractAddress = contract.options.address
-    logger.info(
-      { contractAddress, event, fromBlock: fromBlock.toString(), toBlock: toBlock.toString() },
-      'Getting past events'
-    )
-    const pastEvents = await contract.getPastEvents(event, { fromBlock, toBlock, filter })
-    logger.debug({ contractAddress, event, count: pastEvents.length }, 'Past events obtained')
-    return pastEvents
-  } catch (e) {
-    throw new Error(`${event} events cannot be obtained`)
+// `getEvents` uses JSON-RPC 2.0 batch requests to call getBlockNumber('latest') and getLogs(fromBlock, toBlock) in one
+// request-response cycle. This ensures that the block number and logs are from the same RPC node.
+// Since `eth_getLogs` does not return an error if `toBlock` is larger than largest block number known to the RPC node,
+//   getBlockNumber('latest') being served by a node synced to block 100, then
+//   getLogs(fromBlock: 99, toBlock: 100) being served by a node synced to block 99
+// could make the caller miss the logs contained in block 100.
+// The caller would think it has processed the logs in block 100 when it really has not.
+async function getEvents({ web3, contract, eventName, fromBlock, toBlock, filter }) {
+  logger.info({
+      address: contract.options.address,
+      event: eventName,
+      fromBlock: fromBlock.toString(),
+      toBlock: toBlock.toString(),
+  }, 'Getting past events');
+
+  // find event named `eventName` from contract ABI
+  const event = contract.options.jsonInterface.find(function(json) {
+    return (json.type === 'event' && json.name === eventName);
+  });
+  if (!event) {
+    throw new Error(`${eventName} not in the contract's ABI`)
   }
+
+  const batch = new BatchRequest(web3)
+  // `toBlock` from the caller should be the latest block minus `getRequiredBlockConfirmations()`
+  batch.add(web3.eth.getBlockNumber.request())
+  const logFilter = encodeEventAbi(web3, contract, event, fromBlock, toBlock, filter)
+  batch.add(web3.eth.getPastLogs.request(logFilter))
+  let results
+  try {
+    results = await batch.execute()
+  } catch (e) {
+    throw new Error(`${eventName} events cannot be obtained: ${e}`)
+  }
+
+  const [ latestBlock, logs ] = results
+  const toBlockN = hexToNumber(toBlock)
+  if (latestBlock < toBlockN) {
+    throw new Error(`${eventName} event cannot be obtained: getEvents(fromBlock: ${hexToNumber(fromBlock)}, toBlock: ${toBlockN}) called when latest block reported by RPC node is ${latestBlock}`)
+  }
+  let events
+  try {
+    events = logs.map((log) => decodeEventAbi(web3, event, log))
+  } catch (e) {
+    throw new Error(`${eventName} events cannot be obtained, event decoding failed: ${e}`);
+  }
+  return events
+}
+
+function encodeEventAbi(web3, contract, event, fromBlock, toBlock, filter) {
+  const params = {
+    address: contract.options.address.toLowerCase(),
+    fromBlock: web3.utils.toHex(fromBlock),
+    toBlock: web3.utils.toHex(toBlock),
+    topics: [event.signature],
+  };
+
+  let indexedTopics = event.inputs.filter(function(i) {
+    return i.indexed === true
+  }).map(function(i) {
+    let value = filter[i.name]
+    if (!value) {
+      return null
+    }
+    return web3.eth.abi.encodeParameter(i.type, value)
+  })
+
+  params.topics = params.topics.concat(indexedTopics);
+  return params;
+}
+
+function decodeEventAbi(web3, event, result) {
+  let argTopics = result.topics.slice(1);
+  result.returnValues = web3.eth.abi.decodeLog(event.inputs, result.data, argTopics);
+  delete result.returnValues.__length__;
+  result.event = event.name;
+  result.signature = !result.topics[0] ? null: result.topics[0];
+  result.raw = {
+    data: result.data,
+    topics: result.topics,
+  };
+  delete result.data;
+  delete result.topics;
+  return result;
 }
 
 module.exports = {

--- a/validator/src/watcher.js
+++ b/validator/src/watcher.js
@@ -129,8 +129,9 @@ async function main({ sendToQueue }) {
     const toBlock = lastBlockToProcess
 
     const events = await getEvents({
+      web3: web3Instance,
       contract: eventContract,
-      event: config.event,
+      eventName: config.event,
       fromBlock,
       toBlock,
       filter: config.eventFilter


### PR DESCRIPTION
Patch `getEvents` to use JSON-RPC 2.0 batch requests to call getBlockNumber('latest') and getLogs(fromBlock, toBlock) in one
request-response cycle. This ensures that the block number and logs are from the same RPC node.
Since `eth_getLogs` does not return an error if `toBlock` is larger than largest block number known to the RPC node,
  getBlockNumber('latest') being served by a node synced to block 100, then
  getLogs(fromBlock: 99, toBlock: 100) being served by a node synced to block 99
could make the caller miss the logs contained in block 100.
The caller would think it has processed the logs in block 100 when it really has not