### PR TITLE
Bridge UI uses prefetched data from monitor

### DIFF
--- a/deployment/frontend/docker-compose.yml
+++ b/deployment/frontend/docker-compose.yml
@@ -4,6 +4,11 @@ services:
   nginx:
     image: jwilder/nginx-proxy
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "2m"
+        max-file: "10"
     ports:
       - 80:80
       - 443:443
@@ -16,6 +21,11 @@ services:
 
   letsencrypt:
     image: jrcs/letsencrypt-nginx-proxy-companion
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "2m"
+        max-file: "10"
     restart: always
     volumes_from:
       - nginx

--- a/deployment/ui/docker-compose.yml
+++ b/deployment/ui/docker-compose.yml
@@ -7,6 +7,11 @@ services:
   ui:
     image: thundercore/bridge-ui
     build: ../../ui
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "2m"
+        max-file: "10"
     environment:
       VIRTUAL_HOST: $UI_HOSTNAME
       LETSENCRYPT_HOST: $UI_HOSTNAME

--- a/deployment/ui/docker-compose.yml
+++ b/deployment/ui/docker-compose.yml
@@ -1,5 +1,8 @@
 version: '2'
 
+volumes:
+  statics:
+
 services:
   ui:
     image: thundercore/bridge-ui
@@ -8,6 +11,8 @@ services:
       VIRTUAL_HOST: $UI_HOSTNAME
       LETSENCRYPT_HOST: $UI_HOSTNAME
     env_file: ./.env
+    volumes:
+      - statics:/statics
 
 networks:
   default:

--- a/deployment/validator/docker-compose.yml
+++ b/deployment/validator/docker-compose.yml
@@ -29,8 +29,8 @@ services:
     logging:
       driver: json-file
       options:
-        max-size: '20m'
-        max-file: '5'
+        max-size: '5m'
+        max-file: '10'
 
   bridge_request:
     extends: bridge

--- a/monitor/docker-compose.yaml
+++ b/monitor/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3.2"
+services:
+  monitor:
+    image: thunder_bridge/monitor
+    build: .
+    ports:
+     - "4000:3000"
+    environment:
+     - REDIS_URL=redis://redis
+    command: npm run start
+    depends_on:
+      - redis
+  redis:
+    image: "redis:4"
+    ports:
+     - "6379:6379"

--- a/monitor/index.js
+++ b/monitor/index.js
@@ -66,7 +66,10 @@ const gauges = {}
 
 
 
-const G_STATUSBRIDGES = mkGaugedataRow(["totalSupply", "deposits", "depositValue", "withdrawals", "withdrawalValue", "requiredSignatures"], ["network", "token"]);
+const G_STATUSBRIDGES = mkGaugedataRow(
+  ["totalSupply", "deposits", "depositValue", "depositUsers", "withdrawals", "withdrawalValue", "withdrawalUsers", "requiredSignatures"],
+  ["network", "token"]
+);
 const G_STATUS = mkGaugedataRow(["balanceDiff", "lastChecked", "requiredSignaturesMatch", "validatorsMatch"], ["token"]);
 const G_VALIDATORS = mkGaugedataRow(["balance", "leftTx", "gasPrice"], ["network", "token", "validator"]);
 
@@ -157,14 +160,11 @@ async function checkVBalances(token) {
 }
 
 
-
 for(let token in config) {
   const updater = ((token)=>()=>{checkStatus(token); checkVBalances(token)})(token);
   updater();
   setInterval(updater, config[token].UPDATE_PERIOD);
 }
-
-
 
 
 const server = express();

--- a/monitor/package-lock.json
+++ b/monitor/package-lock.json
@@ -1967,6 +1967,21 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "json-bigint": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.1.tgz",
+      "integrity": "sha512-DGWnSzmusIreWlEupsUelHrhwmPPE+FiQvg+drKfk2p+bdEYa5mp4PJ8JsCWqae0M2jQNb0HPvnwvf1qOTThzQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+        }
+      }
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",

--- a/monitor/package.json
+++ b/monitor/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^5.0.1",
     "express": "^4.16.3",
     "ioredis": "^4.17.3",
+    "json-bigint": "^0.3.1",
     "node-fetch": "^2.1.2",
     "prom-client": "^11.5.0",
     "promise-retry": "^2.0.1",

--- a/monitor/utils/contract.js
+++ b/monitor/utils/contract.js
@@ -2,7 +2,7 @@ const { toBN } = require('web3').utils
 
 const ONE = toBN(1)
 const TWO = toBN(2)
-const queryRange = toBN(300)
+const queryRange = toBN(1000)
 
 function *getPastEventsIter({ contract, event, fromBlock, toBlock, options, token }) {
   console.log(`${token} *getPastEventsIter: ${event} from: ${fromBlock} to: ${toBlock}`)

--- a/monitor/utils/redisClient.js
+++ b/monitor/utils/redisClient.js
@@ -1,4 +1,5 @@
 const Redis = require('ioredis')
+const JSONbig = require('json-bigint')
 
 const prefix = 'monitor'
 const lastProcessedBlockKey = 'lastProcessedBlock'
@@ -7,7 +8,7 @@ Redis.prototype.getProcessedResult = async function (token, name) {
   const key = `${prefix}-cache-${token}-${name}`
   const obj = await this.get(key)
   console.log(`${token} getLastProcessedResult: ${name}`, obj)
-  return JSON.parse(obj)
+  return JSONbig.parse(obj)
 }
 
 Redis.prototype.storeProcessedResult = async function (token, name, obj) {

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -8,6 +8,10 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    location /statics/ {
+        alias   /statics/;
+    }
+
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2510,6 +2510,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -5442,6 +5451,12 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -5703,465 +5718,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "optional": true,
       "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.3.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.12.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.6",
-          "bundled": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true
-        }
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
       }
     },
     "fstream": {
@@ -14635,7 +14198,32 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.30",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {
@@ -14933,31 +14521,6 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "websocket@git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "requires": {
-        "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
-        "yaeti": "^0.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -53,7 +53,7 @@ export class App extends React.Component {
         <div className="app-container">
           {showMobileMenu && <Route render={() => <div className="mobile-menu-open" />} />}
           <Route exact path="/" component={Bridge} />
-          <Route exact path="/events" component={RelayEvents} />
+          { /* <Route exact path="/events" component={RelayEvents} /> */ }
           <Route exact path="/status" component={StatusPage} />
           <Route exact path="/statistics" component={StatisticsPage} />
         </div>

--- a/ui/src/components/StatisticsPage.js
+++ b/ui/src/components/StatisticsPage.js
@@ -30,7 +30,7 @@ export class StatisticsPage extends React.Component {
           <div className="statistics-bridge-container">
             <span className="statistics-bridge-title statistics-title">Bridge Statistics</span>
             <BridgeStatistics
-              users={homeStore.statistics.finished ? homeStore.statistics.users.size : ''}
+              users={homeStore.statistics.finished ? homeStore.statistics.users : ''}
               totalBridged={
                 homeStore.statistics.finished ? homeStore.statistics.totalBridged.toString() : ''
               }

--- a/ui/src/stores/ForeignStore.js
+++ b/ui/src/stores/ForeignStore.js
@@ -29,7 +29,7 @@ import ERC20Bytes32Abi from './utils/ERC20Bytes32.abi'
 import BN from 'bignumber.js'
 import { processLargeArrayAsync } from './utils/array'
 import { fromDecimals } from './utils/decimals'
-import { ReadPrometheusStatus, ReadValidators } from './utils/PrometheusStatus'
+import { ReadPrometheusStatus, ReadValidators, LoadPrometheusFile } from './utils/PrometheusStatus'
 
 class ForeignStore {
   @observable
@@ -128,9 +128,9 @@ class ForeignStore {
 
   async setForeign(tokenName) {
     // Load status file every 10s
-    this.status = require(process.env.REACT_APP_MONITOR_STATUS_FILE)
-    setInterval(() => {
-      this.status = require(process.env.REACT_APP_MONITOR_STATUS_FILE)
+    this.status = await LoadPrometheusFile()
+    setInterval(async () => {
+      this.status = await LoadPrometheusFile()
     }, 10000)
 
     if (tokenName === 'DAI') {

--- a/ui/src/stores/ForeignStore.js
+++ b/ui/src/stores/ForeignStore.js
@@ -6,7 +6,6 @@ import {
   getMinPerTxLimit,
   getForeignLimit,
   getPastEvents,
-  getTotalSupply,
   getBalanceOf,
   getErc677TokenAddress,
   getSymbol,
@@ -30,6 +29,7 @@ import ERC20Bytes32Abi from './utils/ERC20Bytes32.abi'
 import BN from 'bignumber.js'
 import { processLargeArrayAsync } from './utils/array'
 import { fromDecimals } from './utils/decimals'
+import { ReadPrometheusStatus, ReadValidators } from './utils/PrometheusStatus'
 
 class ForeignStore {
   @observable
@@ -118,7 +118,21 @@ class ForeignStore {
     this.setForeign()
   }
 
+  readStatistics(name, defaultVal, formatter) {
+    return ReadPrometheusStatus(this.status, this.tokenName, 'foreign', name, defaultVal, formatter)
+  }
+
+  readValidators() {
+    return ReadValidators(this.status, this.tokenName, 'foreign')
+  }
+
   async setForeign(tokenName) {
+    // Load status file every 10s
+    this.status = require(process.env.REACT_APP_MONITOR_STATUS_FILE)
+    setInterval(() => {
+      this.status = require(process.env.REACT_APP_MONITOR_STATUS_FILE)
+    }, 10000)
+
     if (tokenName === 'DAI') {
       this.FOREIGN_BRIDGE_ADDRESS = process.env.REACT_APP_FOREIGN_DAI_BRIDGE_ADDRESS
     } else {
@@ -134,15 +148,15 @@ class ForeignStore {
     await this.getTokenInfo()
     this.getMinPerTxLimit()
     this.getMaxPerTxLimit()
-    this.getEvents()
+    // this.getEvents()
     this.getTokenBalance()
     this.getCurrentLimit()
     this.getFee()
     this.getValidators()
-    this.getFeeEvents()
+    // this.getFeeEvents()
     setInterval(() => {
       this.getBlockNumber()
-      this.getEvents()
+      // this.getEvents()
       this.getTokenBalance()
       this.getCurrentLimit()
     }, 15000)
@@ -213,9 +227,9 @@ class ForeignStore {
   @action
   async getTokenBalance() {
     try {
-      this.totalSupply = await getTotalSupply(this.tokenContract)
+      this.totalSupply = this.readStatistics('totalSupply', 0, x => this.foreignWeb3.utils.toBN(x).toString())
       this.web3Store.getWeb3Promise.then(async () => {
-        this.balance = await getBalanceOf(this.tokenContract, this.web3Store.defaultAccount.address)
+        this.balance = await getBalanceOf(this.tokenContract, this.web3Store.defaultAccount.address, this.tokenDecimals)
         balanceLoaded()
       })
     } catch (e) {
@@ -390,7 +404,7 @@ class ForeignStore {
         .call()
       this.validatorsCount = await this.foreignBridgeValidators.methods.validatorCount().call()
 
-      this.validators = await getValidatorList(foreignValidatorsAddress, this.foreignWeb3.eth)
+      this.validators = this.readValidators()
     } catch (e) {
       console.error(e)
     }

--- a/ui/src/stores/HomeStore.js
+++ b/ui/src/stores/HomeStore.js
@@ -28,7 +28,7 @@ import {
 } from './utils/bridgeMode'
 import ERC20Bytes32Abi from './utils/ERC20Bytes32.abi'
 import { getRewardableData } from './utils/rewardable'
-import { ReadPrometheusStatus, ReadValidators } from './utils/PrometheusStatus'
+import { ReadPrometheusStatus, ReadValidators, LoadPrometheusFile } from './utils/PrometheusStatus'
 
 async function asyncForEach(array, callback) {
   for (let index = 0; index < array.length; index++) {
@@ -154,9 +154,9 @@ class HomeStore {
 
   async setHome(tokenName) {
     // Load status file every 10s
-    this.status = require(process.env.REACT_APP_MONITOR_STATUS_FILE)
-    setInterval(() => {
-      this.status = require(process.env.REACT_APP_MONITOR_STATUS_FILE)
+    this.status = await LoadPrometheusFile()
+    setInterval(async () => {
+      this.status = await LoadPrometheusFile()
     }, 10000)
 
     if (tokenName === 'DAI') {

--- a/ui/src/stores/utils/PrometheusStatus.js
+++ b/ui/src/stores/utils/PrometheusStatus.js
@@ -26,3 +26,7 @@ export function ReadValidators(resp, tokenName, network) {
   }
   return ret
 }
+
+export async function LoadPrometheusFile() {
+  return (await fetch(process.env.REACT_APP_MONITOR_STATUS_FILE)).json()
+}

--- a/ui/src/stores/utils/PrometheusStatus.js
+++ b/ui/src/stores/utils/PrometheusStatus.js
@@ -1,0 +1,28 @@
+
+function readPrometheusStatus(resp, field, tokenName, network, name, fallbackValue, formatter) {
+  const token = tokenName.includes('USD')? 'USDT': 'DAI'
+  let ret;
+  try {
+    ret = resp[token][field][network][name]
+  } catch (e) {
+    ret = fallbackValue
+  }
+  return formatter(ret)
+}
+
+export function ReadPrometheusStatus(resp, tokenName, network, name, fallbackValue, formatter) {
+  return readPrometheusStatus(resp, 'status', tokenName, network, name, fallbackValue, formatter)
+}
+
+export function ReadPrometheusVStatus(resp, tokenName, network, name, fallbackValue, formatter) {
+  return readPrometheusStatus(resp, 'v_status', tokenName, network, name, fallbackValue, formatter)
+}
+
+export function ReadValidators(resp, tokenName, network) {
+  const validators = ReadPrometheusVStatus(resp, tokenName, network, 'validators', {}, (x)=>x)
+  let ret = []
+  for(const validator in validators) {
+    ret.push(validator)
+  }
+  return ret
+}

--- a/ui/src/stores/utils/contract.js
+++ b/ui/src/stores/utils/contract.js
@@ -53,15 +53,13 @@ export const getDecimals = contract => contract.methods.decimals().call()
 
 export const getMessage = (contract, messageHash) => contract.methods.message(messageHash).call()
 
-export const getTotalSupply = async contract => {
+export const getTotalSupply = async (contract, decimals) => {
   const totalSupply = await contract.methods.totalSupply().call()
-  const decimals = await contract.methods.decimals().call()
   return fromDecimals(totalSupply, decimals)
 }
 
-export const getBalanceOf = async (contract, address) => {
+export const getBalanceOf = async (contract, address, decimals) => {
   const balance = await contract.methods.balanceOf(address).call()
-  const decimals = await contract.methods.decimals().call()
   return fromDecimals(balance, decimals)
 }
 

--- a/validator/config/base.config.js
+++ b/validator/config/base.config.js
@@ -50,6 +50,7 @@ let validations = {
   FOREIGN_VALIDATOR_REQUIRED_BALANCE: envalid.num({ default: 0.1 }),
   HOME_BLOCK_TIME: envalid.num({ default: 1000 }),
   FOREIGN_BLOCK_TIME: envalid.num({ default: 1000 }),
+  GAS_PRICE_BUMP_INTERVAL: envalid.num({ default: 60 * 1000 }),
 }
 
 const env = envalid.cleanEnv(process.env, validations, {})

--- a/validator/e2e/docker-compose-infra.yaml
+++ b/validator/e2e/docker-compose-infra.yaml
@@ -1,20 +1,38 @@
 version: '2'
+volumes:
+  home_data:
+  foreign_data:
+  redis_data:
+  rabbit_data:
+
 services:
   home-chain:
     build: thunder
+    restart: always
+    volumes:
+      - home_data:/thunder/pala-dev/dataDir/single
     ports:
       - "8540:8546"
       - "8541:8545"
   foreign-chain:
     build: thunder
+    restart: always
+    volumes:
+      - foreign_data:/thunder/pala-dev/dataDir/single
     ports:
       - "8542:8545"
   redis:
     image: "redis:4"
+    restart: always
+    volumes:
+      - redis_data:/data
     ports:
      - "6379:6379"
   rabbit:
     image: "rabbitmq:3-management"
+    restart: always
+    volumes:
+      - rabbit_data:/var/lib/rabbitmq/mnesia
     ports:
       - "15672:15672"
       - "5672:5672"

--- a/validator/scripts/crash-test.py
+++ b/validator/scripts/crash-test.py
@@ -9,7 +9,7 @@ import docker
 
 def get_containers(client):
     # Match local chain naming.
-    containers = [c for c in client.containers.list() if c.name.startswith('v')]
+    containers = [c for c in client.containers.list()]
     containers.sort(key=lambda x: x.name)
     return containers
 

--- a/validator/src/lib/sender.ts
+++ b/validator/src/lib/sender.ts
@@ -126,7 +126,7 @@ export class SenderWeb3Impl implements SenderWeb3 {
       to: this.validator.address,
       value: toWei(toBN('0')),
       gas: 21000 * 2,
-      gasPrice: (await this.getPrice(Math.floor(Date.now() / 1000))).toString(),
+      gasPrice: (await this.getPrice(Date.now())).toString(),
     }
 
     this.logger.debug(txConfig, 'Send transaction to self')

--- a/validator/src/services/gasPrice.js
+++ b/validator/src/services/gasPrice.js
@@ -153,9 +153,9 @@ function getPrice(timestamp) {
   }
 
   let gasPrice = '0'
-  const dt = Math.floor(Date.now() / 1000) - timestamp
+  const dt = Date.now() - timestamp
    // Bump gasPrice every 5 mins
-  const speed = Math.floor(dt / 300)
+  const speed = Math.floor(dt / process.env.GAS_PRICE_BUMP_INTERVAL)
 
   if (speed == 0) {
     gasPrice = cachedGasPrice.standard

--- a/validator/test/gasPrice.test.js
+++ b/validator/test/gasPrice.test.js
@@ -111,21 +111,24 @@ describe('gasPrice', () => {
         instant: instant,
       })
 
-      const now = Math.floor(Date.now() / 1000)
+      const now = Math.floor(Date.now())
+      // Set bump interval to 5min
+      process.env.GAS_PRICE_BUMP_INTERVAL = Number(300 * 1000)
 
       expect(getPrice(now)).to.equal(standard, 'should use standard speed type')
-      expect(getPrice(now - 350)).to.equal(fast, 'should use fast speed type')
-      expect(getPrice(now - 650)).to.equal(instant, 'should use instant speed type')
-      expect(getPrice(now - 950)).to.equal(toGWei(7+(7-3)*1))
-      expect(getPrice(now - 1250)).to.equal(toGWei(7+(7-3)*2))
+      expect(getPrice(now - 350 * 1000)).to.equal(fast, 'should use fast speed type')
+      expect(getPrice(now - 650 * 1000)).to.equal(instant, 'should use instant speed type')
+      expect(getPrice(now - 950 * 1000)).to.equal(toGWei(7+(7-3)*1))
+      expect(getPrice(now - 1250 * 1000)).to.equal(toGWei(7+(7-3)*2))
       // The maximum gas price will be GAS_PRICE_BOUNDARIES.MAX after a long time
-      expect(getPrice(now - 100000)).to.equal(max, 'should use instant speed type')
+      expect(getPrice(now - 100000 * 1000)).to.equal(max, 'should use instant speed type')
     })
+
     it('set price from env', async () => {
       process.env.SET_GAS_PRICE = 1000
-      const now = Math.floor(Date.now() / 1000)
+      const now = Math.floor(Date.now())
       expect(getPrice(now)).to.equal('1000', 'should use gas price from env')
-      expect(getPrice(now - 300)).to.equal('1000', 'should use gas price from env')
+      expect(getPrice(now - 350 * 1000)).to.equal('1000', 'should use gas price from env')
       process.env.SET_GAS_PRICE = undefined
     })
   })


### PR DESCRIPTION
In testnet environment, we did the stress test and produced 19k transactions within 1 month. This will make bridge UI break because the number of `getPastLog` responses are too large. Browser will hang for a long time.

This PR change the data source from the chain to prefetched data of monitor and reduce the amount of queries to infura.